### PR TITLE
Fixing a Kotlin Multiplatform issue

### DIFF
--- a/plugin/src/main/kotlin/org/lwjgl/lwjglUtil.kt
+++ b/plugin/src/main/kotlin/org/lwjgl/lwjglUtil.kt
@@ -181,13 +181,13 @@ private fun KotlinDependencyHandler.impl(modules: Collection<Lwjgl.Module>) {
 }
 
 private fun KotlinDependencyHandler.impl(module: Lwjgl.Module) {
-    implementation("${Lwjgl.group}:${module.artifact}:${Lwjgl.version}")
+    implementation("${Lwjgl.group}:${module.artifact}:${Lwjgl.version.string}")
     if (module.hasNative)
         if (Lwjgl.nativesForEveryPlatform)
             for (platform in Lwjgl.platforms)
-                runtimeOnly("${Lwjgl.group}:${module.artifact}:${Lwjgl.version}:natives-$platform")
+                runtimeOnly("${Lwjgl.group}:${module.artifact}:${Lwjgl.version.string}:natives-$platform")
         else
-            runtimeOnly("${Lwjgl.group}:${module.artifact}:${Lwjgl.version}:natives-${Lwjgl.runningPlatform}")
+            runtimeOnly("${Lwjgl.group}:${module.artifact}:${Lwjgl.version.string}:natives-${Lwjgl.runningPlatform}")
 }
 
 interface Version {


### PR DESCRIPTION
The lwjglImplementation method accesses the wrong repository, for example, trying to access lwjgl 3_3_2 instead of 3.3.2 where the repository actually lives.