### PR TITLE
lwjgl 3.3.4 v0.0.35

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This:
 
 ```kotlin
 
-val lwjglVersion = "3.3.2-SNAPSHOT"
+val lwjglVersion = "3.3.4-SNAPSHOT"
 val lwjglNatives = "natives-linux"
 
 repositories {
@@ -94,7 +94,7 @@ becomes
 
 ```kotlin
 plugins {
-    id("org.lwjgl.plugin") version "0.0.34"
+    id("org.lwjgl.plugin") version "0.0.35"
 }
 repositories {
     mavenCentral()
@@ -102,7 +102,7 @@ repositories {
 }
 dependencies {
     lwjgl {
-        version = Snapshot.`3_3_2` // default to Release.latest, that is Release.`3_3_2`
+        version = Snapshot.`3_3_4` // default to Release.latest, that is Release.`3_3_4`
         implementation(Preset.everything) 
     }
 }
@@ -111,7 +111,7 @@ The corresponding natives will be loaded under the hood for all the modules whic
 By default, only the natives of the running platform will be included. If you want to include them all, set 
 `nativesForEveryPlatform = true`
 
-The default version is the latest stable, that is `3.3.2`, if you want to override this
+The default version is the latest stable, that is `3.3.4`, if you want to override this
 ```kotlin
 lwjgl {
     version = Release.`3_3_0` // down to 3.1.0

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -37,7 +37,7 @@ dependencies {
 }
 
 group = "org.lwjgl"
-version = "0.0.34"
+version = "0.0.35"
 
 publishing {
     publications.create<MavenPublication>("maven") {

--- a/plugin/src/main/kotlin/org/lwjgl/lwjglUtil.kt
+++ b/plugin/src/main/kotlin/org/lwjgl/lwjglUtil.kt
@@ -154,7 +154,8 @@ object Lwjgl {
     )
 
     object Addons {
-        val `joml 1_10_5` = "org.joml:joml:1.10.5"
+        val `joml 1_10_7` = "org.joml:joml:1.10.7"
+        val `joml_primitives 1_10_0` = "org.joml:joml-primitives:1.10.0"
         val `awt 0_1_8` = "org.lwjglx:lwjgl3-awt:0.1.8"
         val `steamworks4j 1_9_0` = "com.code-disaster.steamworks4j:steamworks4j:1.9.0"
         val `steamworks4j-server 1_9_0` = "com.code-disaster.steamworks4j:steamworks4j-server:1.9.0"
@@ -197,6 +198,8 @@ interface Version {
 }
 
 enum class Release : Version {
+    `3_3_4`,
+    `3_3_3`,
     `3_3_2`,
     `3_3_1`,
     `3_3_0`,
@@ -221,6 +224,7 @@ enum class Release : Version {
 }
 
 enum class Snapshot : Version {
+    `3_3_4`,
     `3_3_3`,
     `3_3_2`,
     `3_3_1`,


### PR DESCRIPTION
As the title says. 

Updated the versions to include stable `3.3.3` and `3.3.4` as well as snapshot versions of `3.3.4`.

Also updated joml to `1.10.7` and added joml primitives as that is an addon listed on the website not included.

Feel free to request any changes, may have missed something but looked good from a quick inspection.